### PR TITLE
Version 0.1.4

### DIFF
--- a/confparser/parser.py
+++ b/confparser/parser.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from yaml import load, Loader
 
 
-class DotDict(defaultdict):
+class ConfParserDict(defaultdict):
     def __init__(self, *args, **kwargs):
         if args or kwargs:
             dict.__init__(self, *args, **kwargs)
@@ -11,8 +11,8 @@ class DotDict(defaultdict):
     def __getattr__(self, key):
         value = self.__getitem__(key)
 
-        if isinstance(value, dict) and not isinstance(value, DotDict):
-            value = DotDict(value)
+        if isinstance(value, dict) and not isinstance(value, ConfParserDict):
+            value = ConfParserDict(value)
 
         return value
 
@@ -44,6 +44,9 @@ class ConfParser:
         if path:
             self.load_from_path(path=path)
         elif conf_dict:
+            if not isinstance(conf_dict, dict):
+                raise ConfParserException(msg='type of conf_dict must be dict')
+
             self.config = conf_dict
 
     def load_from_path(self, path: str) -> None:
@@ -53,5 +56,5 @@ class ConfParser:
         except IOError:
             raise ConfParserException(msg='Read file error')
 
-    def to_obj(self) -> 'DotDict':
-        return DotDict(config=self.config).config
+    def to_obj(self) -> ConfParserDict:
+        return ConfParserDict(config=self.config).config

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="confparser",
-    version="0.1.2",
+    version="0.1.4",
     author="teamhide",
     author_email="padocon@naver.com",
     description="Python config parser library",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 import pytest
 
 from confparser import ConfParser
-from confparser.parser import ConfParserException, DotDict
+from confparser.parser import ConfParserException, ConfParserDict
 
 
 def test_parser_with_do_not_exist_path():
@@ -17,6 +17,20 @@ def test_parser_with_none_path_and_none_conf_dict():
 def test_parser_with_path_and_conf_dict():
     with pytest.raises(ConfParserException):
         ConfParser(path='./config.yml', conf_dict={'debug': True})
+
+
+def test_parser_conf_dict_type_is_not_dict():
+    with pytest.raises(ConfParserException):
+        ConfParser(conf_dict=1)
+
+    with pytest.raises(ConfParserException):
+        ConfParser(conf_dict='test')
+
+    with pytest.raises(ConfParserException):
+        ConfParser(conf_dict=())
+
+    with pytest.raises(ConfParserException):
+        ConfParser(conf_dict=[])
 
 
 def test_parser_with_conf_dict():
@@ -35,11 +49,11 @@ def test_parser_with_conf_dict():
             }
         },
     ).to_obj()
-    assert isinstance(config, DotDict)
+    assert isinstance(config, ConfParserDict)
     assert config.debug is True
-    assert isinstance(config.server, DotDict)
-    assert isinstance(config.server.dev, DotDict)
-    assert isinstance(config.server.prod, DotDict)
+    assert isinstance(config.server, ConfParserDict)
+    assert isinstance(config.server.dev, ConfParserDict)
+    assert isinstance(config.server.prod, ConfParserDict)
     assert config.server.dev.debug is True
     assert config.server.dev.port == 8000
     assert config.server.prod.debug is False
@@ -49,11 +63,11 @@ def test_parser_with_conf_dict():
 def test_parser_with_path():
     config = ConfParser(path='./config.yml').to_obj()
 
-    assert isinstance(config, DotDict)
+    assert isinstance(config, ConfParserDict)
     assert config.debug is True
-    assert isinstance(config.server, DotDict)
-    assert isinstance(config.server.dev, DotDict)
-    assert isinstance(config.server.prod, DotDict)
+    assert isinstance(config.server, ConfParserDict)
+    assert isinstance(config.server.dev, ConfParserDict)
+    assert isinstance(config.server.prod, ConfParserDict)
     assert config.server.dev.debug is True
     assert config.server.dev.port == 8000
     assert config.server.prod.debug is False


### PR DESCRIPTION
Add prevent code if type of conf_dict is not dictionary
    
1. Add prevent code if type of conf_dict is not dictionary
2. Rename DotDict to ConfParserDict
3. Add test codes
4. Bump up to 0.1.4
